### PR TITLE
Use the first line of description if there is no summary

### DIFF
--- a/tmpl/method.tmpl
+++ b/tmpl/method.tmpl
@@ -17,8 +17,8 @@ var self = this;
 <div class="summary">
     <?js if (data.summary) { ?>
     <?js= summary ?>
-    <?js } else { ?>
-    ...
+    <?js } else if (data.description){ ?>
+    <?js= data.description.split('<\/p>')[0]?></p>
     <?js } ?>
 </div>
 <?js } ?>


### PR DESCRIPTION
If there is no @summary tag present use the first line of the
description. We already have a convention of writing the first
line as the summary, so adding new tags to our code might be
too verbose.